### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ fi
 export ANCHORE_CLI_PASS=""
 
 echo "Adding image ${IMAGE_TO_SCAN} to Anchore engine at ${ANCHORE_CLI_URL}"
-IMAGE_DIGEST=`anchore-cli image add ${IMAGE_TO_SCAN} | grep Digest | awk '{print $3}'`
+IMAGE_DIGEST=`anchore-cli image add ${IMAGE_TO_SCAN} | grep "Image Digest" | awk '{print $3}'`
 if [ -z $IMAGE_DIGEST ]; then
   echo "Backend cannot pull the requested image, wrong credentials or unavailable image, aborting"
   exit 1


### PR DESCRIPTION
```
anchore-cli image add <image>
Image Digest: <digest>
Parent Digest: <digest>
Analysis Status: not_analyzed
Image Type: docker
Image ID: <id>
Dockerfile Mode: None
Distro: None
Distro Version: None
Size: None
Architecture: None
Layer Count: None
```


Image digest is not the only digest returned by the API
If the grep command gets both matches, it will return
```
sha256:23ca5e27c7bdc877a1c2190bd094437b937be2569b57aa27008d2dc90198d2de
sha256:23ca5e27c7bdc877a1c2190bd094437b937be2569b57aa27008d2dc90198d2de
```
Which breaks scan task like this
```
Error: Got unexpected extra argument (sha256:<hash>
.Usage: anchore-cli image get [OPTIONS] INPUT_IMAGE
Try "anchore-cli image get --help" for help.
```