### PR TITLE
Better retry, waiting and timeout for 'analyzed' step and getting scan report

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,23 +31,25 @@ echo "Waiting for analysis to complete"
 result=0
 user_time=0
 retries=0
+notanalyzed=1 #1 when failure, 0 when success
 while [ $user_time -lt $TIMEOUT ]; do
   anchore-cli image get $IMAGE_DIGEST | grep analyzed > /dev/null
-  if [ $? -ne 0 ]; then
+  notanalyzed=$?
+  if [ $notanalyzed -ne 0 ]; then
     echo -n "."
     sleep 10
     let "user_time=user_time+10"
   else
     let "retries=retries+1"
-    if [ $retries -lt $MAX_RETRIES ]; then
+    if [ $notanalyzed -ne 0 ] && [ $retries -lt $MAX_RETRIES ]; then
+      echo -n "#"
       sleep 10
     else
-      result=1
       break
     fi
   fi
 done
-[ $result -ne 1 ] && echo "Scan timedout." && exit 1
+[ $notanalyzed -ne 0 ] && echo "Scan timedout." && exit 1
 
 echo "Analysis complete"
 anchore-cli evaluate check ${IMAGE_DIGEST} --tag $IMAGE_TAG


### PR DESCRIPTION
Initial implementation would wait fixed 2x10s after the image was uploaded to Secure because of number of retries code being always executed, then tried to get scan report.

That would be too much if the scan was already cached in Secure and immediately available, or too little if scan result was delayed (when the script says 'analyzed', it means it has received the image, not that the scan has finished).

Now if the scan report is available immediately, there is no delay getting it, and if it's not, a  retry for the timeout period is done in incremental steps of 5s, 10s, 15s... to avoid overloading the backend when things get slow.